### PR TITLE
Disable executing Deno.env

### DIFF
--- a/deps.ts
+++ b/deps.ts
@@ -1,6 +1,6 @@
 export { HmacSha256 } from "https://deno.land/std@0.51.0/hash/sha256.ts";
 export { Base64 } from "https://deno.land/x/bb64/mod.ts";
-export {
+export type {
   APIGatewayProxyEvent,
   APIGatewayProxyResult,
   Context,


### PR DESCRIPTION
## Summary

This PR disables `Deno.env` on deno playground, based on #16 