### PR TITLE
fix: Replace eval with run to sandbox by default

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -75,3 +75,4 @@ $RECYCLE.BIN/
 
 .vercel
 .now
+.vscode

--- a/README.md
+++ b/README.md
@@ -4,17 +4,22 @@
 
 Deno playground scratchpad, inspired by golang's play.golang.org
 
-Be aware that this will run unprevilleged code on your servers. For safety reasons, I'm adding a time-based execution limit (default is 3s, but can be overridden by setting `SCRIPT_EXECUTION_TIMEOUT` envvars).
+Be aware that this will run unprevilleged code on your servers. For safety
+reasons, I'm adding a time-based execution limit (default is 3s, but can be
+overridden by setting `SCRIPT_EXECUTION_TIMEOUT` envvars).
 
 ## Available API routes
 
-All results are in text format. HTTP response status indicates whether the request is completed successfully or not.
+All results are in text format. HTTP response status indicates whether the
+request is completed successfully or not.
 
 as always, 200 means OK - 500 means there's error somewhere in your code.
 
 ### POST /api/eval
-Interpret deno source code, and get result back.
-To use unstable features, pass `unstable=1` queryparams to the URL. To interpret as typescript, pass `typescript=1` queryparams to the URL.
+
+Interpret deno source code, and get result back. To use unstable features, pass
+`unstable=1` queryparams to the URL. To interpret as typescript, pass
+`typescript=1` queryparams to the URL.
 
 ```
 curl -X POST \
@@ -24,6 +29,7 @@ curl -X POST \
 ```
 
 ### POST /api/fmt
+
 Format deno source code, and get formatted result back.
 
 ```

--- a/api/eval.ts
+++ b/api/eval.ts
@@ -4,5 +4,5 @@ import createCommandHandler from "../lib/createCommandHandler.ts";
 export async function handler(
   evt: APIGatewayProxyEvent,
 ): Promise<APIGatewayProxyResult> {
-  return createCommandHandler("eval")(evt);
+  return createCommandHandler("run")(evt);
 }

--- a/api/index.ts
+++ b/api/index.ts
@@ -1,7 +1,4 @@
-import {
-  APIGatewayProxyEvent,
-  APIGatewayProxyResult,
-} from "../deps.ts";
+import { APIGatewayProxyEvent, APIGatewayProxyResult } from "../deps.ts";
 import template from "../lib/template.ts";
 import { checkUid } from "./share.ts";
 

--- a/api/share.ts
+++ b/api/share.ts
@@ -5,11 +5,7 @@ import {
   HmacSha256,
 } from "../deps.ts";
 
-import {
-  SHARE_SALT,
-  JSONBIN_URL,
-  JSONBIN_TOKEN,
-} from "../config.ts";
+import { JSONBIN_TOKEN, JSONBIN_URL, SHARE_SALT } from "../config.ts";
 
 function generateHash(body: string) {
   const h = new HmacSha256(SHARE_SALT);

--- a/lib/createCommandHandler.ts
+++ b/lib/createCommandHandler.ts
@@ -4,17 +4,7 @@ import {
   Base64,
 } from "../deps.ts";
 
-const beforeTimeout = (promise: Promise<any>, timeout: number = 0) => {
-  const error = "Timeout occured before promise was resolved";
-  const wait = new Promise((_, reject) =>
-    setTimeout(() => reject(new Error(error)), timeout)
-  );
-  return Promise.race([wait, promise]);
-};
-
-type SupportedDenoSubCommand = "eval" | "fmt";
-
-const BLACKLISTED_API = ["Deno.run", "Deno.env"];
+type SupportedDenoSubCommand = "run" | "fmt";
 
 export default function createCommandHandler(
   commandType: SupportedDenoSubCommand,
@@ -27,58 +17,55 @@ export default function createCommandHandler(
     const [_, queryString] = path.split("?");
     const qs = new URLSearchParams(queryString || "");
     const source = Base64.fromBase64String(body).toString();
-    // Blacklist some deno APIs
-    if (BLACKLISTED_API.some((api) => source.includes(api))) {
-      return {
-        statusCode: 500,
-        body: "Blacklisted APIs: ['Deno.env', 'Deno.run']",
-      };
-    }
+    const encoder = new TextEncoder();
+    const decoder = new TextDecoder();
     const cmd = ["deno", commandType];
-    if (commandType === "fmt") {
-      cmd.push("-");
-    } else {
-      if (qs.has("ts")) cmd.push("--ts");
-      if (qs.has("unstable")) cmd.push("--unstable");
-      cmd.push(source);
+    if (qs.has("unstable")) {
+      cmd.push("--unstable");
     }
+    cmd.push("-");
+
     const executor = Deno.run({
       cmd,
       stdin: "piped",
       stdout: "piped",
       stderr: "piped",
     });
-    if (commandType === "fmt") {
-      const encoder = new TextEncoder();
-      await executor.stdin?.write(encoder.encode(source));
-      executor.stdin?.close();
-    }
-    try {
-      // @ts-ignore
-      const { code } = await beforeTimeout(
-        executor.status(),
-        parseInt(Deno.env.get("SCRIPT_EXECUTION_TIMEOUT") || "3000", 10),
-      );
-      let output;
-      let outputString;
-      if (code === 0) {
-        output = await executor.output();
-      } else {
-        output = await executor.stderrOutput();
+
+    await executor.stdin?.write(encoder.encode(source));
+    executor.stdin?.close();
+    let killed = false;
+    const timer = setTimeout(() => {
+      killed = true;
+      executor.kill(Deno.Signal.SIGKILL);
+    }, parseInt(Deno.env.get("SCRIPT_EXECUTION_TIMEOUT") || "3000", 10));
+
+    const [status, stdout, stderr] = await Promise.all([
+      executor.status(),
+      executor.output(),
+      executor.stderrOutput(),
+    ]);
+
+    clearTimeout(timer);
+
+    executor.close();
+
+    if (!status.success) {
+      if (killed) {
+        return formatResponse("Exceeding execution time limit", 500);
       }
-      const textDecoder = new TextDecoder();
-      outputString = textDecoder.decode(output);
-      return {
-        statusCode: code === 0 ? 200 : 500,
-        body: outputString,
-      };
-    } catch (e) {
-      Deno.kill(executor.pid, Deno.Signal.SIGTERM);
-      console.error(e);
-      return {
-        statusCode: 500,
-        body: "Exceeding execution time limit",
-      };
+      return formatResponse(decoder.decode(stderr), 500);
     }
+    return formatResponse(decoder.decode(stdout), 200);
+  };
+}
+
+function formatResponse(body: string, statusCode: number) {
+  return {
+    statusCode,
+    body,
+    headers: {
+      "Content-Type": "text/plain; charset=UTF-8",
+    },
   };
 }


### PR DESCRIPTION
fixes #16 

I have tried to minimize code changes.  Let me know if there is any problem.

```ts
console.log(JSON.stringify(Deno.env.toObject()))
```
Above code should throw a permission error now. 

I recommend switching to vercel-deno which is more maintained now for runtime in vercel but that is out of scope for this PR. 